### PR TITLE
[codex] Centralize CI tool versions in package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '22'
+          node-version-file: package.json
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "author": "",
   "license": "ISC",
   "packageManager": "pnpm@10.24.0",
+  "engines": {
+    "node": "22"
+  },
   "devDependencies": {
     "@marp-team/marp-cli": "^4.2.3"
   }


### PR DESCRIPTION
## Summary

- Move pnpm version selection from GitHub Actions workflow inputs into `package.json` `packageManager` where applicable.
- Move single Node.js CI version selections into `package.json` `engines.node` and have `actions/setup-node` read `node-version-file: package.json`.
- Leave existing major versions and exact versions unchanged; this only centralizes the source of truth.

## Impact

CI keeps using the same pnpm and Node versions, but the versions now live with the project metadata. This makes local tooling and CI easier to compare.

## Validation

- `jq empty` on updated `package.json`
- `git diff --check`
- `actionlint .github/workflows/*.y*ml`
