### PR TITLE
Test pnpm 11.13.0 self-update

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@11.11.0",
+  "packageManager": "pnpm@11.13.0",
   "engines": {
     "node": "24"
   },


### PR DESCRIPTION
## Summary

- update `packageManager` from `pnpm@11.11.0` to exact `pnpm@11.13.0`
- keep `package.json#packageManager` as the single pnpm version source
- leave GitHub Actions workflows unchanged

## Why

PR #54 fails in `pnpm/action-setup` while self-updating from pnpm 11.7.0 to 11.12.0 with `Cannot use 'in' operator to search for 'integrity' in undefined`. This isolated draft PR verifies whether pnpm 11.13.0 avoids that self-installer failure.

The lockfile was refreshed with pnpm 11.13.0, but its resolved contents did not change.

## Validation

- `pnpm install --lockfile-only` with pnpm 11.13.0
- `pnpm install --frozen-lockfile` with pnpm 11.13.0
- `pnpm build:html`
- `pnpm build:pdf`
- `pnpm build:pptx`
- `pnpm build:png`
- `pnpm build:jpeg`
- `pinact run --check`
- `zizmor --format github .`

The existing `test` script was not run because it is a placeholder that always exits with status 1.
